### PR TITLE
Improve sonar trigger workflow

### DIFF
--- a/.github/workflows/sonar-trigger.yml
+++ b/.github/workflows/sonar-trigger.yml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: trigger-sonar-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -23,6 +27,7 @@ jobs:
     name: Trigger Sonar analysis
     uses: WrenSecurity/.github/.github/workflows/sonar-maven.yml@main
     with:
+      commit_sha: ${{ github.event.workflow_run.head_sha }}
       java_version: 21
       project_key: 'WrenSecurity_wrenig'
       pull_request: ${{ needs.prepare.outputs.pull_request }}


### PR DESCRIPTION
This PR introduces concurrency in the Sonar workflow to ensure, that a full Sonar analysis runs only on the latest commit, when multiple pushes occur in quick succession.